### PR TITLE
Use 'svn list --recursive' to get the versioned svn files.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 0.15 (unreleased)
 -----------------
 
+* Use ``svn list --recursive`` to list the known subversion files.
+  Note that you need to do an ``svn update`` after you have added new
+  files.
+  [maurits]
+
 * Normalize the paths of all files, avoiding some duplicate misses of
   directories.
   [maurits]

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -286,9 +286,8 @@ class Subversion(VCS):
     @staticmethod
     def get_versioned_files():
         """List all files under SVN control in the current directory."""
-        output = run(['svn', 'st', '-vq'])
-        return sorted(line[41:] for line in output.splitlines()
-                      if line[41:] != '.')
+        output = run(['svn', 'list', '--recursive'])
+        return sorted(output.splitlines())
 
 
 def detect_vcs():

--- a/tests.py
+++ b/tests.py
@@ -253,6 +253,14 @@ class TestSvn(VCSMixin, unittest.TestCase):
 
     def _commit(self):
         self._run('svn', 'commit', '-m', 'Initial')
+        # Update the information in the local copy, otherwise 'svn
+        # list --recursive' gives no results.
+        self._run('svn', 'up')
+
+    def test_get_vcs_files_added_but_uncommitted(self):
+        # For Subversion you have to commit the files and do an svn up
+        # before it has effect.
+        pass
 
 
 def test_suite():


### PR DESCRIPTION
I have not been hit by this in practice yet, but the tests for subversion do not pass for me with the previous subversion command because my username is too long.

Alternatively, the code would need to be smarter about knowing at which point to split the lines returned by `svn st -vq` or it would need to use the `--xml` argument and learn how to parse that.

Note that we need to skip the `test_get_vcs_files_added_but_uncommitted` test for Subversion now.
You need to commit the changes and do an 'svn up' before 'svn list' gives the latest results back.

With the previous 'svn st -vq' you get unwanted results when a
committer name is too long, for example in the tests:

``` python
((Pdb)) print output
                 1        1 mauritsvanrees .
                 1        1 mauritsvanrees b.txt
                 1        1 mauritsvanrees c
                 1        1 mauritsvanrees c/d.txt
((Pdb)) sorted(line[41:] for line in output.splitlines())
[u's .', u's b.txt', u's c', u's c/d.txt']
```
