### PR TITLE
Skip tests instead of fail'ing if VCS <foo> command not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 install:
     - pip install coverage coveralls mock
 script:
-    - coverage run --source=check_manifest setup.py test -q
+    - SKIP_NO_TESTS=1 coverage run --source=check_manifest setup.py test -q
     - coverage run --source=check_manifest --append check_manifest.py
 after_script:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
     - 2.6
     - 2.7
@@ -6,6 +7,11 @@ python:
     - 3.3
     - 3.4
     - pypy
+env:
+    - FORCE_TEST_VCS=bzr
+    - FORCE_TEST_VCS=git
+    - FORCE_TEST_VCS=hg
+    - FORCE_TEST_VCS=svn
 install:
     - pip install coverage coveralls mock
 script:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:
 test:
 	detox
 check:
-	tox
+	SKIP_NO_TESTS=1 tox
 
 .PHONY: coverage
 coverage:

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -285,7 +285,7 @@ class Mercurial(VCS):
     @staticmethod
     def get_versioned_files():
         """List all files under Mercurial control in the current directory."""
-        output = run(['hg', 'status', '-ncam', '.'])
+        output = run(['hg', 'status', '-ncamd', '.'])
         return add_directories(output.splitlines())
 
 

--- a/tests.py
+++ b/tests.py
@@ -1192,7 +1192,8 @@ class TestCheckManifest(unittest.TestCase):
                       sys.stderr.getvalue())
 
     def test_missing_source_files(self):
-        # XXX: fails when self._vcs is BzrHelper() or HgHelper()
+        # https://github.com/mgedmin/check-manifest/issues/32
+        # XXX: fails when self._vcs is BzrHelper()
         from check_manifest import check_manifest
         self._create_repo_with_code()
         self._add_to_vcs('missing.py')

--- a/tests.py
+++ b/tests.py
@@ -1064,6 +1064,16 @@ class TestCheckManifest(unittest.TestCase):
             f.write("# wow. such code. so amaze\n")
         self._vcs._add_to_vcs(['setup.py', 'sample.py'])
 
+    def _create_repo_with_code_in_subdir(self):
+        os.mkdir('subdir')
+        os.chdir('subdir')
+        self._create_repo_with_code()
+        # NB: when self._vcs is SvnHelper, we're actually in
+        # ./subdir/checout rather than in ./subdir
+        subdir = os.path.basename(os.getcwd())
+        os.chdir(os.pardir)
+        return subdir
+
     def _add_to_vcs(self, filename, content=''):
         if os.path.sep in filename and not os.path.isdir(os.path.dirname(filename)):
             os.makedirs(os.path.dirname(filename))
@@ -1084,23 +1094,15 @@ class TestCheckManifest(unittest.TestCase):
         self.assertTrue(check_manifest())
 
     def test_relative_pathname(self):
-        # XXX: fails when self._vcs is SvnHelper()
         from check_manifest import check_manifest
-        os.mkdir('subdir')
-        os.chdir('subdir')
-        self._create_repo_with_code()
-        os.chdir(os.pardir)
-        self.assertTrue(check_manifest('subdir'))
+        subdir = self._create_repo_with_code_in_subdir()
+        self.assertTrue(check_manifest(subdir))
 
     def test_relative_python(self):
-        # XXX: fails when self._vcs is SvnHelper()
         from check_manifest import check_manifest
-        os.mkdir('subdir')
-        os.chdir('subdir')
-        self._create_repo_with_code()
-        os.chdir(os.pardir)
+        subdir = self._create_repo_with_code_in_subdir()
         python = os.path.relpath(sys.executable)
-        self.assertTrue(check_manifest('subdir', python=python))
+        self.assertTrue(check_manifest(subdir, python=python))
 
     def test_suggestions(self):
         from check_manifest import check_manifest

--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,9 @@ except ImportError:
 import mock
 
 
+CAN_SKIP_TESTS = os.getenv('SKIP_NO_TESTS', '') == ''
+
+
 def rmtree(path):
     """A version of rmtree that can remove read-only files on Windows.
 
@@ -745,7 +748,7 @@ class VCSHelper(object):
 class VCSMixin(object):
 
     def setUp(self):
-        if not self.vcs.is_installed():
+        if not self.vcs.is_installed() and CAN_SKIP_TESTS:
             self.skipTest("%s is not installed" % self.vcs.command)
         self.tmpdir = tempfile.mkdtemp(prefix='test-', suffix='-check-manifest')
         self.olddir = os.getcwd()


### PR DESCRIPTION
I have svn, hg and git installed, but not bzr. Any VCS tests will currently fail due to a missing command. Eg: If a user only uses git, svn, hg and bzr tests will fail. 

They should instead be skipped with an appropriate message: "skipping . 'foo' command not installed" or equivalent.

```
======================================================================
ERROR: test_get_vcs_files (tests.TestBzr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 770, in test_get_vcs_files
    self._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 756, in _init_vcs
    self.vcs._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 831, in _init_vcs
    self._run('bzr', 'init')
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 724, in _run
    stderr=subprocess.STDOUT)
  File "/usr/local/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_get_vcs_files_added_but_uncommitted (tests.TestBzr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 781, in test_get_vcs_files_added_but_uncommitted
    self._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 756, in _init_vcs
    self.vcs._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 831, in _init_vcs
    self._run('bzr', 'init')
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 724, in _run
    stderr=subprocess.STDOUT)
  File "/usr/local/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_get_vcs_files_in_a_subdir (tests.TestBzr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 791, in test_get_vcs_files_in_a_subdir
    self._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 756, in _init_vcs
    self.vcs._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 831, in _init_vcs
    self._run('bzr', 'init')
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 724, in _run
    stderr=subprocess.STDOUT)
  File "/usr/local/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

======================================================================
ERROR: test_get_vcs_files_nonascii_filenames (tests.TestBzr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 803, in test_get_vcs_files_nonascii_filenames
    self._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 756, in _init_vcs
    self.vcs._init_vcs()
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 831, in _init_vcs
    self._run('bzr', 'init')
  File "/mnt/home/user/repos/freebsd/ports/devel/py-check-manifest/work/check-manifest-0.22/tests.py", line 724, in _run
    stderr=subprocess.STDOUT)
  File "/usr/local/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

----------------------------------------------------------------------
Ran 87 tests in 8.683s

FAILED (errors=4)
```