### PR TITLE
Fix non-ascii confusion for Mac OSX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 * Normalize unicode representation and case of filenames. (`issue #47
   <https://github.com/mgedmin/check-manifest/issues/47>`__).
 
+
 0.25 (2015-05-27)
 -----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 0.26 (unreleased)
 -----------------
 
+* Normalize unicode representation and case of filenames. (`issue #47
+  <https://github.com/mgedmin/check-manifest/issues/47>`__).
 
 0.25 (2015-05-27)
 -----------------

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import unicodedata
 import zipfile
 from contextlib import contextmanager, closing
 from xml.etree import cElementTree as ET
@@ -377,11 +378,24 @@ def get_vcs_files():
 
 
 def normalize_names(names):
+    """Normalize file names.
+    """
+    return list(map(normalize_name, names))
+
+
+def normalize_name(name):
     """Some VCS print directory names with trailing slashes.  Strip them.
 
     Easiest is to normalize the path.
+
+    And encodings may trip us up too, especially when comparing lists
+    of files.  Plus maybe lowercase versus uppercase.
     """
-    return [os.path.normpath(name) for name in names]
+    name = os.path.normpath(name)
+    name = os.path.normcase(name)
+    name = unicodify(name)
+    name = unicodedata.normalize('NFC', name)
+    return name
 
 
 def add_directories(names):

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -393,7 +393,10 @@ def normalize_name(name):
     name = os.path.normpath(name)
     name = os.path.normcase(name)
     name = unicodify(name)
-    name = unicodedata.normalize('NFC', name)
+    if sys.platform == 'darwin':
+        # Mac OSX may have problems comparing non-ascii filenames, so
+        # we convert them.
+        name = unicodedata.normalize('NFC', name)
     return name
 
 

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -378,8 +378,7 @@ def get_vcs_files():
 
 
 def normalize_names(names):
-    """Normalize file names.
-    """
+    """Normalize file names."""
     return list(map(normalize_name, names))
 
 

--- a/tests.py
+++ b/tests.py
@@ -850,6 +850,9 @@ class GitHelper(VCSHelper):
         self._run('git', 'config', 'user.email', 'test@example.com')
 
     def _add_to_vcs(self, filenames):
+        # Note that we use --force to prevent errors when we want to
+        # add foo.egg-info and the user running the tests has
+        # '*.egg-info' in her global .gitignore file.
         self._run('git', 'add', '--force', '--', *filenames)
 
     def _commit(self):

--- a/tests.py
+++ b/tests.py
@@ -743,7 +743,11 @@ class VCSHelper(object):
         if rc:
             print(' '.join(command))
             print(stdout)
-            raise subprocess.CalledProcessError(rc, command[0], output=stdout)
+            try:
+                raise subprocess.CalledProcessError(rc, command[0], output=stdout)
+            except TypeError:
+                # BBB Python 2.6
+                raise subprocess.CalledProcessError(rc, command[0])
 
 
 class VCSMixin(object):

--- a/tests.py
+++ b/tests.py
@@ -846,7 +846,7 @@ class GitHelper(VCSHelper):
         self._run('git', 'config', 'user.email', 'test@example.com')
 
     def _add_to_vcs(self, filenames):
-        self._run('git', 'add', '--', *filenames)
+        self._run('git', 'add', '--force', '--', *filenames)
 
     def _commit(self):
         self._run('git', 'commit', '-m', 'Initial')


### PR DESCRIPTION
This fixes issue #47. A ``check-manifest`` in the Plone Intranet project that I mention there works without problem after this fix. Let's see what Travis says about it.

Note that Python 2.6 has some test failures on Mac, but they were already there before I started. Ah, but they fail because of this:

```
$ python2.6
Python 2.6.9 (unknown, Mar  2 2015, 21:39:52) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
>>> import locale
>>> locale.getpreferredencoding()
'mac-roman'
```

Right. On 2.7 this is the sane `UTF-8`. So that is an issue with my local Python 2.6 and should be of no concern here.