### PR TITLE
Fix detection of git submodules.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 0.28 (2015-11-02)
 -----------------
 
+* Fix detection of git submodules.
+
 
 0.27 (2015-11-02)
 -----------------

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -282,6 +282,11 @@ class VCS(object):
 class Git(VCS):
     metadata_name = '.git'
 
+    @classmethod
+    def detect(cls, location):
+        # .git can be a file for submodules
+        return os.path.exists(os.path.join(location, cls.metadata_name))
+
     @staticmethod
     def get_versioned_files():
         """List all files versioned by git in the current directory."""


### PR DESCRIPTION
For git submodules, .git is a file.

The problem with this PR is, that the tests won't fail if the fix is reverted. The whole of check_manifest works with getcwd. So there currently is no way to inspect which path ``detect`` actually found, which would be necessary to write a test that actually fails when ``isdir`` instead of ``exists`` is used.

Any suggestions?