### PR TITLE
Add .hgsigs to IGNORE

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -483,7 +483,7 @@ IGNORE = [
     '*.egg-info/*', # always generated
     'setup.cfg',    # always generated, sometimes also kept in source control
     # it's not a problem if the sdist is lacking these files:
-    '.hgtags', '.hgignore', '.gitignore', '.bzrignore',
+    '.hgtags', '.hgsigs', '.hgignore', '.gitignore', '.bzrignore',
     '.gitattributes',
     '.travis.yml',
     # it's convenient to ship compiled .mo files in sdists, but they shouldn't


### PR DESCRIPTION
`.hgsigs` is used by the Mercurial [GPG extension](https://www.mercurial-scm.org/wiki/GpgExtension).