### PR TITLE
Accept a list of bad idea file patterns to ignore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 0.32 (unreleased)
 -----------------
 
-- Nothing changed yet.
+* New config/command line option to ignore bad ideas (ignore-bad-ideas)
+  (`issue #67 <https://github.com/mgedmin/check-manifest/issues/67>`__).
+  Contributed by Brecht Machiels.
 
 
 0.31 (2016-01-28)

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,9 @@ Command-line reference
                             (default: /home/mg/.venv/bin/python)
       --ignore patterns     ignore files/directories matching these comma-
                             separated patterns (default: None)
+      --ignore-bad-ideas patterns
+                            ignore bad idea files/directories matching these
+                            comma-separated patterns (default: [])
 
 
 Configuration
@@ -99,6 +102,12 @@ ignore
 ignore-default-rules
     If set to ``true``, your ``ignore`` patterns will replace the default
     ignore list instead of adding to it.
+
+ignore-bad-ideas
+    A list of newline separated filename patterns that will be ignored by
+    check-manifest's generated files check.  Use this if you want to keep
+    generated files in your version control system, even though it is generally
+    a bad idea.
 
 
 .. |buildstatus| image:: https://api.travis-ci.org/mgedmin/check-manifest.svg?branch=master

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -544,7 +544,6 @@ CFG_IGNORE_BAD_IDEAS = (CFG_SECTION_CHECK_MANIFEST, 'ignore-bad-ideas')
 def read_config():
     """Read configuration from setup.cfg."""
     # XXX modifies global state, which is kind of evil
-    ignore_bad_ideas = []
     config = ConfigParser.ConfigParser()
     config.read(['setup.cfg'])
     if not config.has_section(CFG_SECTION_CHECK_MANIFEST):
@@ -557,7 +556,8 @@ def read_config():
         IGNORE.extend(p for p in patterns if p)
     if config.has_option(*CFG_IGNORE_BAD_IDEAS):
         lines = config.get(*CFG_IGNORE_BAD_IDEAS).splitlines()
-        IGNORE_BAD_IDEAS.extend(line.strip() for line in lines if line)
+        patterns = [p.strip() for p in lines]
+        IGNORE_BAD_IDEAS.extend(p for p in patterns if p)
 
 
 def read_manifest():

--- a/tests.py
+++ b/tests.py
@@ -541,13 +541,16 @@ class TestConfiguration(unittest.TestCase):
         os.chdir(self.tmpdir)
         self.OLD_IGNORE = check_manifest.IGNORE
         self.OLD_IGNORE_REGEXPS = check_manifest.IGNORE_REGEXPS
+        self.OLD_IGNORE_BAD_IDEAS = check_manifest.IGNORE_BAD_IDEAS
         check_manifest.IGNORE = ['default-ignore-rules']
         check_manifest.IGNORE_REGEXPS = ['default-ignore-regexps']
+        check_manifest.IGNORE_BAD_IDEAS = []
 
     def tearDown(self):
         import check_manifest
         check_manifest.IGNORE = self.OLD_IGNORE
         check_manifest.IGNORE_REGEXPS = self.OLD_IGNORE_REGEXPS
+        check_manifest.IGNORE_BAD_IDEAS = self.OLD_IGNORE_BAD_IDEAS
         os.chdir(self.oldpwd)
         shutil.rmtree(self.tmpdir)
 

--- a/tests.py
+++ b/tests.py
@@ -1390,6 +1390,7 @@ class TestCheckManifest(unittest.TestCase):
 
     def test_ignore_bad_ideas(self):
         from check_manifest import check_manifest
+        self._create_repo_with_code()
         with open('setup.cfg', 'w') as f:
             f.write('[check-manifest]\n'
                     'ignore =\n'
@@ -1397,7 +1398,6 @@ class TestCheckManifest(unittest.TestCase):
                     'ignore-bad-ideas =\n'
                     '  *.mo\n'
                     '  subdir/bar.egg-info\n')
-        self._create_repo_with_code()
         self._add_to_vcs('foo.egg-info')
         self._add_to_vcs('moo.mo')
         self._add_to_vcs('subdir/bar.egg-info')

--- a/tests.py
+++ b/tests.py
@@ -1400,7 +1400,7 @@ class TestCheckManifest(unittest.TestCase):
                     '  subdir/bar.egg-info\n')
         self._add_to_vcs('foo.egg-info')
         self._add_to_vcs('moo.mo')
-        self._add_to_vcs('subdir/bar.egg-info')
+        self._add_to_vcs(os.path.join('subdir', 'bar.egg-info'))
         self.assertFalse(check_manifest())
         self.assertIn("you have foo.egg-info in source control!",
                       sys.stderr.getvalue())


### PR DESCRIPTION
- new command line option --ignore-bad-ideas wich takes a list of
  patterns like --ignore.
- new config section 'ignore-bad-ideas' similar to 'ignore'

Closes #67