### PR TITLE
Normalizes path for git and git submodules

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -19,6 +19,7 @@ import argparse
 import fnmatch
 import locale
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -274,7 +275,7 @@ def add_prefix_to_each(prefix, filelist):
         ['foo/bar/a', 'foo/bar/b', 'foo/bar/c/d']
 
     """
-    return [os.path.join(prefix, name) for name in filelist]
+    return [posixpath.join(prefix, name) for name in filelist]
 
 
 class VCS(object):
@@ -302,7 +303,7 @@ class Git(VCS):
         files = cls._git_ls_files()
         submodules = cls._list_submodules()
         for subdir in submodules:
-            subdir = os.path.relpath(subdir)
+            subdir = os.path.relpath(subdir).replace(os.path.sep, '/')
             files += add_prefix_to_each(subdir, cls._git_ls_files(subdir))
         return add_directories(files)
 


### PR DESCRIPTION
`_git_ls_files()` returns file paths with forward slashes. For files
in submodules, add_prefix_to_each() is called to prefix all the
submodule files with the relative path to the project root. On Windows,
the relative path contains backslashes. Since not every file in the
project is in a submodule, the combined list of files ended up with
some files that use forward slashes and others that use backslashes.

For project structures where the submodules share a path segment with
the project source, this caused `add_directories()` to create duplicate
directory entries in the list of files. The duplicate entries would
result in a traceback with a WindowsError when `os.mkdir()` was called
to create the same directory a second time.

See #61 for more details.

This commit ensures the list of files contains only forward slashes
before calling `add_directories()`, eliminating the duplicate directory
entries.