### PR TITLE
Adjust wording of "MANIFEST.in is not in order"

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -935,7 +935,7 @@ def zest_releaser_check(data):
         return
     try:
         if not check_manifest(source_tree):
-            if not ask("MANIFEST.in is not in order. "
+            if not ask("MANIFEST.in has problems. "
                        " Do you want to continue despite that?", default=False):
                 sys.exit(1)
     except Failure as e:


### PR DESCRIPTION
The old wording confused me for a moment ("why does MANIFEST.in need to be sorted in a particular way?")