### PR TITLE
Ignore .github by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 -----------------
 
 - Claim Python 3.7 support.
+- Added GitHub templates to default ignore patterns.
 
 
 0.37 (2018-04-12)

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ ignore
         .gitignore
         .bzrignore
         .gitattributes
+        .github/*
         .travis.yml
         Jenkinsfile
         *.mo

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -529,6 +529,7 @@ IGNORE = [
     # it's not a problem if the sdist is lacking these files:
     '.hgtags', '.hgsigs', '.hgignore', '.gitignore', '.bzrignore',
     '.gitattributes',
+    '.github/*',    # GitHub template files
     '.travis.yml',
     'Jenkinsfile',
     # it's convenient to ship compiled .mo files in sdists, but they shouldn't

--- a/tests.py
+++ b/tests.py
@@ -287,6 +287,7 @@ class Tests(unittest.TestCase):
     def test_strip_sdist_extras(self):
         from check_manifest import strip_sdist_extras
         filelist = list(map(os.path.normpath, [
+            '.github/ISSUE_TEMPLATE/bug_report.md',
             '.gitignore',
             '.travis.yml',
             'setup.py',
@@ -329,6 +330,7 @@ class Tests(unittest.TestCase):
             recursive-exclude src/zope *.sh
         """)
         filelist = list(map(os.path.normpath, [
+            '.github/ISSUE_TEMPLATE/bug_report.md',
             '.gitignore',
             'setup.py',
             'setup.cfg',


### PR DESCRIPTION
Used for GitHub template files. Python packages need not include them.

Fixes #89