### PR TITLE
Replace use of nose with pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
 [bdist_wheel]
 universal = 1
 
-[nosetests]
-with-doctest = 1
-exe = 1
-
 [tool:pytest]
 norecursedirs = dist build tmp .* *.egg-info
 python_files = tests.py check_manifest.py

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     extras_require={
         'test': [
             'mock >= 3.0.0',
+            'pytest',
         ],
     },
     entry_points={

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import codecs
-import doctest
 import locale
 import os
 import posixpath
@@ -1787,10 +1786,3 @@ class TestCheckManifest(unittest.TestCase):
                 "some files listed as being under source control are missing:\n"
                 "  missing.py",
                 sys.stderr.getvalue())
-
-
-def test_suite():
-    return unittest.TestSuite([
-        unittest.defaultTestLoader.loadTestsFromName(__name__),
-        doctest.DocTestSuite('check_manifest'),
-    ])

--- a/tox.ini
+++ b/tox.ini
@@ -5,24 +5,15 @@ envlist =
 [testenv]
 passenv = LANG LC_CTYPE LC_ALL MSYSTEM
 extras = test
-deps =
-    nose
 commands =
-    nosetests {posargs}
+    pytest {posargs}
 
 [testenv:coverage]
 deps =
-    {[testenv]deps}
     coverage
 commands =
-    coverage run -m nose
+    coverage run -m pytest
     coverage report -m --fail-under=100
-
-[testenv:py]
-commands =
-    python --version
-    nosetests {posargs}
-
 
 [testenv:check-manifest]
 basepython = python3


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3,
2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will
> likely cease without a new person/team to take over maintainership.
> New projects should consider using Nose2, py.test, or just plain
> unittest/unittest2.

pytest was already configured, so use that instead.

Rename [pytest] to [tool:pytest] to avoid deprecation warning.