### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE.rst
+
 [nosetests]
 with-doctest = 1
 exe = 1


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

Helps project comply with its own license:

> The above copyright notice and this permission notice shall be
> included in all copies or substantial portions of the Software.