### PR TITLE
Pass python_requires argument to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,9 @@ import ast
 import email.utils
 import os
 import re
-import sys
 
 from setuptools import setup
 
-
-if sys.version_info < (2, 7):
-    sys.exit("Python 2.7 or newer is required for check-manifest")
-
-if (3, 0) <= sys.version_info < (3, 4):
-    sys.exit("Python 3.4 or newer is required for check-manifest")
 
 here = os.path.dirname(__file__)
 
@@ -62,6 +55,7 @@ setup(
     py_modules=['check_manifest'],
     zip_safe=False,
     test_suite='tests.test_suite',
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[],
     extras_require={
         'test': ['mock'],


### PR DESCRIPTION
Helps pip decide what version of the library to install.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

> If your project only runs on certain Python versions, setting the
> python_requires argument to the appropriate PEP 440 version specifier
> string will prevent pip from installing the project on other Python
> versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords

> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440)
> for the Python version, used to specify the Requires-Python defined in
> PEP 345.