### PR TITLE
Allow for reading configuration from a pyproject.toml file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,20 +74,30 @@ Command-line reference
 Configuration
 -------------
 
-You can tell check-manifest to ignore certain file patterns by adding a
-``check-manifest`` section to your package's ``setup.cfg``.  Example::
+You can configure check-manifest to ignore certain file patterns using
+a ``[tool.check-manifest]`` section in your ``pyproject.toml`` file or
+a ``[check-manifest]`` section in either ``setup.cfg`` or
+``tox.ini``. Examples::
 
+    # pyproject.toml
+    [tool.check-manifest]
+    ignore = [".travis.yml"]
+
+    # setup.cfg or tox.ini
     [check-manifest]
     ignore =
         .travis.yml
 
+Note that lists are newline separated in the ``setup.cfg`` and
+``tox.ini`` files.
+
 The following options are recognized:
 
 ignore
-    A list of newline separated filename patterns that will be ignored by
-    check-manifest.  Use this if you want to keep files in your version
-    control system that shouldn't be included in your source distributions.
-    The default ignore list is ::
+    A list of filename patterns that will be ignored by check-manifest.
+    Use this if you want to keep files in your version control system
+    that shouldn't be included in your source distributions.  The
+    default ignore list is ::
 
         PKG-INFO
         *.egg-info
@@ -109,10 +119,10 @@ ignore-default-rules
     ignore list instead of adding to it.
 
 ignore-bad-ideas
-    A list of newline separated filename patterns that will be ignored by
-    check-manifest's generated files check.  Use this if you want to keep
-    generated files in your version control system, even though it is generally
-    a bad idea.
+    A list of filename patterns that will be ignored by
+    check-manifest's generated files check.  Use this if you want to
+    keep generated files in your version control system, even though
+    it is generally a bad idea.
 
 
 .. |buildstatus| image:: https://api.travis-ci.org/mgedmin/check-manifest.svg?branch=master
@@ -123,4 +133,3 @@ ignore-bad-ideas
 
 .. |coverage| image:: https://coveralls.io/repos/mgedmin/check-manifest/badge.svg?branch=master
 .. _coverage: https://coveralls.io/r/mgedmin/check-manifest
-

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,10 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[],
     extras_require={
-        'test': ['mock'],
+        'pyproject': ['toml'],
+        'test': ['mock', 'toml'],
     },
-    tests_require=['mock'],
+    tests_require=['mock', 'toml'],
     entry_points={
         'console_scripts': [
             'check-manifest = check_manifest:main',

--- a/tests.py
+++ b/tests.py
@@ -618,21 +618,35 @@ class TestConfiguration(unittest.TestCase):
         check_manifest.read_config()
         self.assertEqual(check_manifest.IGNORE, ['default-ignore-rules'])
 
-    def test_read_config_no_section(self):
+    def test_read_setup_config_no_section(self):
         import check_manifest
         with open('setup.cfg', 'w') as f:
             f.write('[pep8]\nignore =\n')
         check_manifest.read_config()
         self.assertEqual(check_manifest.IGNORE, ['default-ignore-rules'])
 
-    def test_read_config_no_option(self):
+    def test_read_pyproject_config_no_section(self):
+        import check_manifest
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.pep8]\nignore = []\n')
+        check_manifest.read_config()
+        self.assertEqual(check_manifest.IGNORE, ['default-ignore-rules'])
+
+    def test_read_setup_config_no_option(self):
         import check_manifest
         with open('setup.cfg', 'w') as f:
             f.write('[check-manifest]\n')
         check_manifest.read_config()
         self.assertEqual(check_manifest.IGNORE, ['default-ignore-rules'])
 
-    def test_read_config_extra_ignores(self):
+    def test_read_pyproject_config_no_option(self):
+        import check_manifest
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.check-manifest]\n')
+        check_manifest.read_config()
+        self.assertEqual(check_manifest.IGNORE, ['default-ignore-rules'])
+
+    def test_read_setup_config_extra_ignores(self):
         import check_manifest
         with open('setup.cfg', 'w') as f:
             f.write('[check-manifest]\nignore = foo\n  bar\n')
@@ -640,7 +654,15 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(check_manifest.IGNORE,
                          ['default-ignore-rules', 'foo', 'bar'])
 
-    def test_read_config_override_ignores(self):
+    def test_read_pyproject_config_extra_ignores(self):
+        import check_manifest
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.check-manifest]\nignore = ["foo", "bar"]\n')
+        check_manifest.read_config()
+        self.assertEqual(check_manifest.IGNORE,
+                         ['default-ignore-rules', 'foo', 'bar'])
+
+    def test_read_setup_config_override_ignores(self):
         import check_manifest
         with open('setup.cfg', 'w') as f:
             f.write('[check-manifest]\nignore = foo\n\n  bar\n')
@@ -649,13 +671,30 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(check_manifest.IGNORE,
                          ['foo', 'bar'])
 
-    def test_read_config_ignore_bad_ideas(self):
+    def test_read_pyproject_config_override_ignores(self):
+        import check_manifest
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.check-manifest]\nignore = ["foo", "bar"]\n')
+            f.write('ignore-default-rules = true\n')
+        check_manifest.read_config()
+        self.assertEqual(check_manifest.IGNORE,
+                         ['foo', 'bar'])
+
+    def test_read_setup_config_ignore_bad_ideas(self):
         import check_manifest
         with open('setup.cfg', 'w') as f:
             f.write('[check-manifest]\n'
                     'ignore-bad-ideas = \n'
                     '  foo\n'
                     '  bar\n')
+        check_manifest.read_config()
+        self.assertEqual(check_manifest.IGNORE_BAD_IDEAS, ['foo', 'bar'])
+
+    def test_read_pyproject_config_ignore_bad_ideas(self):
+        import check_manifest
+        with open('pyproject.toml', 'w') as f:
+            f.write('[tool.check-manifest]\n'
+                    'ignore-bad-ideas = ["foo", "bar"]\n')
         check_manifest.read_config()
         self.assertEqual(check_manifest.IGNORE_BAD_IDEAS, ['foo', 'bar'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv = LANG LC_CTYPE LC_ALL MSYSTEM
 deps =
     mock
     nose
+    toml
 commands =
     nosetests {posargs}
 ## if I run check-manifest here, it breaks my 'make release' :(


### PR DESCRIPTION
PEP 518 has introduced of pyproject.toml and it has been adopted by
other tools as the standard location for tooling configuration. This
allows for the check-manifest configuration to also be loaded from the
pyproject.toml file. Note this requires ``toml`` to be installed,
which is added as an optional extra.