### PR TITLE
Add check-manifest as pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: check-manifest
+    name: check-manifest
+    description: Check the completeness of MANIFEST.in for Python packages.
+    entry: check-manifest
+    language: python
+    pass_filenames: false
+    always_run: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.rst
 include *.py
+include *.yaml
 include tox.ini
 include Makefile
 include .gitignore

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ git-workflow. Add the following to your ``.pre-commit-config.yaml``.
 
     repos:
     -   repo: https://github.com/mgedmin/check-manifest
-        rev: "0.38"
+        rev: "0.39"
         hooks:
         -   id: check-manifest
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,21 @@ ignore-bad-ideas
     it is generally a bad idea.
 
 
+Version control integration
+---------------------------
+
+With `pre-commit <https://pre-commit.com>`_, check-manifest can be part of your
+git-workflow. Add the following to your ``.pre-commit-config.yaml``.
+
+.. code-block:: yaml
+
+    repos:
+    -   repo: https://github.com/mgedmin/check-manifest
+        rev: "0.38"
+        hooks:
+        -   id: check-manifest
+
+
 .. |buildstatus| image:: https://api.travis-ci.org/mgedmin/check-manifest.svg?branch=master
 .. _buildstatus: https://travis-ci.org/mgedmin/check-manifest
 


### PR DESCRIPTION
This PR resolves #100 and adds ``.pre-commit-hooks.yaml`` and a small section to the readme. This section is totally optional and can be deleted if deemed unnecessary.