### PR TITLE
Add "--quiet" argument for reduced output verbosity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 0.40 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Added ``-q``/``--quiet`` command line argument. This will reduce the verbosity
+of informational output, e.g. for use in a CI pipeline.
 
 
 0.39 (2019-06-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 -----------------
 
 - Added ``-q``/``--quiet`` command line argument. This will reduce the verbosity
-of informational output, e.g. for use in a CI pipeline.
+  of informational output, e.g. for use in a CI pipeline.
 
 
 0.39 (2019-06-06)

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -964,10 +964,10 @@ def main():
         help='location for the source tree')
     parser.add_argument('--version', action='version',
                         version='%(prog)s version ' + __version__)
-    parser.add_argument('-v', '--verbose', action='store_true',
-        help='more verbose output')
-    parser.add_argument('-q', '--quiet', action='store_true',
-        help='reduced output verbosity')
+    parser.add_argument('--quiet', action='store_const', dest='quiet',
+                        const=0, default=1, help='reduced output verbosity')
+    parser.add_argument('--verbose', action='store_const', dest='verbose',
+                        const=1, default=0, help='more verbose output')
     parser.add_argument('-c', '--create', action='store_true',
         help='create a MANIFEST.in if missing')
     parser.add_argument('-u', '--update', action='store_true',
@@ -988,11 +988,11 @@ def main():
     if args.ignore_bad_ideas:
         IGNORE_BAD_IDEAS.extend(args.ignore_bad_ideas.split(','))
 
-    if args.verbose:
+    verbosity = args.quiet + args.verbose
+    if verbosity >= 2:
         global VERBOSE
         VERBOSE = True
-
-    if args.quiet:
+    if not verbosity:
         global QUIET
         QUIET = True
 

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -59,6 +59,7 @@ class Failure(Exception):
 #
 
 VERBOSE = False
+QUIET = False
 
 _to_be_continued = False
 def _check_tbc():
@@ -69,6 +70,8 @@ def _check_tbc():
 
 
 def info(message):
+    if QUIET:
+        return
     _check_tbc()
     print(message)
 
@@ -963,6 +966,8 @@ def main():
                         version='%(prog)s version ' + __version__)
     parser.add_argument('-v', '--verbose', action='store_true',
         help='more verbose output')
+    parser.add_argument('-q', '--quiet', action='store_true',
+        help='reduced output verbosity')
     parser.add_argument('-c', '--create', action='store_true',
         help='create a MANIFEST.in if missing')
     parser.add_argument('-u', '--update', action='store_true',
@@ -986,6 +991,10 @@ def main():
     if args.verbose:
         global VERBOSE
         VERBOSE = True
+
+    if args.quiet:
+        global QUIET
+        QUIET = True
 
     try:
         if not check_manifest(args.source_tree, create=args.create,

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -997,9 +997,9 @@ def main():
         help='location for the source tree')
     parser.add_argument('--version', action='version',
                         version='%(prog)s version ' + __version__)
-    parser.add_argument('--quiet', action='store_const', dest='quiet',
+    parser.add_argument('-q', '--quiet', action='store_const', dest='quiet',
                         const=0, default=1, help='reduced output verbosity')
-    parser.add_argument('--verbose', action='store_const', dest='verbose',
+    parser.add_argument('-v', '--verbose', action='store_const', dest='verbose',
                         const=1, default=0, help='more verbose output')
     parser.add_argument('-c', '--create', action='store_true',
         help='create a MANIFEST.in if missing')

--- a/tests.py
+++ b/tests.py
@@ -845,6 +845,34 @@ class TestMain(unittest.TestCase):
         self.assertEqual(check_manifest.IGNORE_BAD_IDEAS,
                          ['x', 'y', 'z'])
 
+    def test_verbose_arg(self):
+        import check_manifest
+        check_manifest.VERBOSE = False
+        sys.argv.append('--verbose')
+        check_manifest.main()
+        self.assertTrue(check_manifest.VERBOSE)
+        check_manifest.VERBOSE = False
+
+    def test_quiet_arg(self):
+        import check_manifest
+        check_manifest.QUIET = False
+        sys.argv.append('--quiet')
+        check_manifest.main()
+        self.assertTrue(check_manifest.QUIET)
+        check_manifest.QUIET = False
+
+    def test_verbose_and_quiet_arg(self):
+        import check_manifest
+        check_manifest.VERBOSE = False
+        check_manifest.QUIET = False
+        sys.argv.append('--verbose')
+        sys.argv.append('--quiet')
+        check_manifest.main()
+        self.assertFalse(check_manifest.VERBOSE)
+        self.assertFalse(check_manifest.QUIET)
+        check_manifest.VERBOSE = False
+        check_manifest.QUIET = False
+
 
 class TestZestIntegration(unittest.TestCase):
 
@@ -1298,6 +1326,14 @@ class TestUserInterface(UIMixin, unittest.TestCase):
         check_manifest.info("Reticulating splines")
         self.assertEqual(sys.stdout.getvalue(),
                          "Reticulating splines\n")
+
+    def test_info_quiet(self):
+        import check_manifest
+        check_manifest.VERBOSE = False
+        check_manifest.QUIET = True
+        check_manifest.info("Reticulating splines")
+        self.assertEqual(sys.stdout.getvalue(), "")
+        check_manifest.QUIET = False
 
     def test_info_begin_continue_end(self):
         import check_manifest


### PR DESCRIPTION
Added ``-q``/``--quiet`` command line argument. This will reduce the verbosity
of informational output, e.g. for use in a CI pipeline. This is often desired in CI or with tools
that only care about the return code on success.