### PR TITLE
Cleanup Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-sudo: required
-dist: xenial
 cache: pip
 python:
     - 2.7


### PR DESCRIPTION
The default distribution is now xenial. It doesn't need to be specified.

The sudo attribute is now deprecated and can be removed.