### PR TITLE
Rewrite the IgnoreList logic to be more distutils-like

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 build/
 tags
 coverage.xml
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
 cache: pip
 python:
-    - 2.7
     - 3.5
     - 3.6
     - 3.7
     - 3.8
-    - pypy
     - pypy3
 env:
     - FORCE_TEST_VCS=bzr

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,28 @@ Changelog
 - Added ``-q``/``--quiet`` command line argument. This will reduce the verbosity
   of informational output, e.g. for use in a CI pipeline.
 
+- Rewrote the ignore logic to be more compatible with distutils.  This might
+  have introduced some regressions, so please file bugs!  One side effect of
+  this is that ``--ignore`` (or the ``ignore`` setting in the config file)
+  is now handled the same way as ``global-exclude`` in a ``MANIFEST.in``, which
+  means:
+
+  - it's matched anywhere in the file tree
+  - it's matched against a filename *suffix* rather than an entire filename,
+    due to https://bugs.python.org/issue14106
+  - it's ignored if it matches a directory
+
+  You can ignore directories only by ignoring every file inside it.
+  There's no way currently of specifying that that works for arbitrarily
+  nested trees, but you can try ``--ignore=dir/*,dir/*/*,dir/*/*/*``
+  until you get the result you want.
+
+  This decision is not cast in stone: I may in the future change the
+  handling of ``--ignore`` to match files and directories, because there's no
+  reason it has to be distutils-compatible.
+
+- Drop Python 2.7 support.
+
 
 0.41 (2020-02-25)
 -----------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -879,11 +879,6 @@ def find_suggestions(filelist):
     suggestions = set()
     unknowns = []
     for filename in filelist:
-        if os.path.isdir(filename):
-            # it's impossible to add empty directories via MANIFEST.in anyway,
-            # and non-empty directories will be added automatically when we
-            # specify patterns for files inside them
-            continue
         for pattern, suggestion in SUGGESTIONS:
             m = pattern.match(filename)
             if m is not None:

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -626,28 +626,36 @@ class IgnoreList(object):
         self._regexps += other._regexps
         return self
 
+    def _path(self, path):
+        return path.replace('/', os.path.sep)
+
     def exclude(self, *patterns):
         for pat in patterns:
+            pat = self._path(pat)
             self._regexps.append(translate_pattern(pat, anchor=True))
         return self
 
     def global_exclude(self, *patterns):
         for pat in patterns:
+            pat = self._path(pat)
             self._regexps.append(translate_pattern(pat, anchor=False))
         return self
 
     def recursive_exclude(self, dirname, *patterns):
+        dirname = self._path(dirname)
         for pat in patterns:
+            pat = self._path(pat)
             self._regexps.append(translate_pattern(pat, prefix=dirname))
         return self
 
     def prune(self, subdir):
+        subdir = self._path(subdir)
         self._regexps.append(translate_pattern(None, prefix=subdir))
         return self
 
     def filter(self, filelist):
         return [name for name in filelist
-                if not any(rx.search(name) for rx in self._regexps)]
+                if not any(rx.search(self._path(name)) for rx in self._regexps)]
 
 
 WARN_ABOUT_FILES_IN_VCS = [

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     python_requires=">=3.5",
     install_requires=['toml', 'pep517'],
     extras_require={
-        'test': ['mock'],
+        'test': ['mock >= 3.0.0'],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -56,7 +54,7 @@ setup(
 
     py_modules=['check_manifest'],
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.5",
     install_requires=['toml', 'pep517'],
     extras_require={
         'test': ['mock'],

--- a/tests.py
+++ b/tests.py
@@ -397,7 +397,7 @@ class Tests(unittest.TestCase):
 
     def test_find_bad_ideas(self):
         from check_manifest import find_bad_ideas
-        filelist = list(map(os.path.normpath, [
+        filelist = [
             '.gitignore',
             'setup.py',
             'setup.cfg',
@@ -411,11 +411,11 @@ class Tests(unittest.TestCase):
             'src/zope/foo/language.mo',
             'src/zope.foo.egg-info',
             'src/zope.foo.egg-info/SOURCES.txt',
-        ]))
-        expected = list(map(os.path.normpath, [
+        ]
+        expected = [
             'src/zope/foo/language.mo',
             'src/zope.foo.egg-info',
-        ]))
+        ]
         self.assertEqual(find_bad_ideas(filelist), expected)
 
     def test_find_suggestions(self):
@@ -426,38 +426,31 @@ class Tests(unittest.TestCase):
                          ([], ['unknown.file~']))
         self.assertEqual(find_suggestions(['README.txt', 'CHANGES.txt']),
                          (['include *.txt'], []))
-        filelist = list(map(os.path.normpath, [
+        filelist = [
             'docs/index.rst',
             'docs/image.png',
             'docs/Makefile',
             'docs/unknown-file',
             'src/etc/blah/blah/Makefile',
-        ]))
+        ]
         expected_rules = [
             'recursive-include docs *.png',
             'recursive-include docs *.rst',
             'recursive-include docs Makefile',
             'recursive-include src Makefile',
         ]
-        expected_unknowns = [os.path.normpath('docs/unknown-file')]
+        expected_unknowns = ['docs/unknown-file']
         self.assertEqual(find_suggestions(filelist),
                          (expected_rules, expected_unknowns))
 
     def test_find_suggestions_generic_fallback_rules(self):
         from check_manifest import find_suggestions
-        n = os.path.normpath
         self.assertEqual(find_suggestions(['Changelog']),
                          (['include Changelog'], []))
         self.assertEqual(find_suggestions(['id-lang.map']),
                          (['include *.map'], []))
-        self.assertEqual(find_suggestions([n('src/id-lang.map')]),
+        self.assertEqual(find_suggestions(['src/id-lang.map']),
                          (['recursive-include src *.map'], []))
-
-    def test_find_suggestions_ignores_directories(self):
-        from check_manifest import find_suggestions
-        with mock.patch('os.path.isdir', lambda d: True):
-            self.assertEqual(find_suggestions(['SOMEDIR']),
-                             ([], []))
 
     def test_is_package(self):
         from check_manifest import is_package

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,py38,pypy,pypy3,flake8
+    py35,py36,py37,py38,pypy3,flake8
 
 [testenv]
 passenv = LANG LC_CTYPE LC_ALL MSYSTEM


### PR DESCRIPTION
This should eliminate most of the inconsistencies with how distutils treats MANIFEST.in files.  (Some inconsistencies remain: distutils allows you to add back previously excluded files.)

The way I went about it:

- explicitly defined the internal canonical format for lists of file names
- changed it to use / instead of os.path.sep
- changed it to omit directories and list only files, which makes ignore handling simpler

To elaborate on the last point, here are some examples:

1. 'exclude foo' in MANIFEST.in works only on regular files,   not directories, but how can we know if all we have is a string?
2. if you exclude all the files in a directory, distutils will omit that directory from the sdist, but it's difficult to do the same when all you have is a list of strings

Next, I changed IgnoreList to avoid fnmatch and be entirely based on regular expressions, and this time I'm using distutils's own translate_pattern() to produce exactly the same regular expressions that distutils itself will use for matching.

This may introduce some surprising behaviour, like 'global-exclude a*.txt' now matches on suffixes of file names, so it would exclude files named bar.txt!  See https://bugs.python.org/issue14106.

Then tests started failing on Python 2.7, but all I get from the `__repr__` is a bunch of opaque `<_sre.SRE_Pattern object at 0xdeadbeef>`, which are impossible to debug.  Therefore I'm declaring Python 2.7 support officially dropped!

check-manifests's own configuration (--ignore or [check-manifest] ignore=) is now treated as a global-exclude statement in MANIFEST.in, which means:

- it's matched anywhere in the file tree
- it's matched against a filename suffix due to the above-mentioned Python bug
- it's ignored if it matches a directory

You can ignore directories only by ignoring every file inside it. There's no way currently of specifying that that works for arbitrarily nested trees, but you can try `--ignore=dir/*,dir/*/*,dir/*/*/*` until you get the result you want.

This decision is not cast in stone: I may in the future change the handling of --ignore to match files and directories, because there's no reason it has to be distutils-compatible.

Expect regressions on Windows.  I'll fix any that I find.

Closes #98, #113.