### PR TITLE
Import distutils after setuptools to avoid warning

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -31,12 +31,14 @@ import tempfile
 import unicodedata
 import zipfile
 from contextlib import closing, contextmanager
-from distutils.text_file import TextFile
 from typing import List, Optional, Union
 from xml.etree import ElementTree as ET
 
 import toml
 from setuptools.command.egg_info import translate_pattern
+
+# import distutils after setuptools to avoid a warning
+from distutils.text_file import TextFile
 
 
 __version__ = '0.43.dev0'


### PR DESCRIPTION
Setuptools started warning about importing distutils before setuptools in version 49.2.0. This is hopefully a trivial fix for it!