### PR TITLE
Fix get_versioned_files() failing when GIT_INDEX_FILE is set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 0.43 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix collecting files versioned by ``git`` when a project has submodules and
+  ``GIT_INDEX_FILE`` is set.  This bug was triggered when ``check-manifest``
+  was run as part of a git hook (
+  `#122 <https://github.com/mgedmin/check-manifest/issues/122>`__,
+  `#123 <https://github.com/mgedmin/check-manifest/pull/123>`__).
 
 
 0.42 (2020-05-03)

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -369,16 +369,6 @@ def strip_toplevel_name(filelist):
     return [name[len(prefix):] for name in names if name != prefix]
 
 
-def add_prefix_to_each(prefix, filelist):
-    """Add a prefix to each name in a file list.
-
-        >>> add_prefix_to_each('foo/bar', ['a', 'b', 'c/d'])
-        ['foo/bar/a', 'foo/bar/b', 'foo/bar/c/d']
-
-    """
-    return [posixpath.join(prefix, name) for name in filelist]
-
-
 class VCS:
 
     def __init__(self, ui):

--- a/tests.py
+++ b/tests.py
@@ -1102,6 +1102,10 @@ class TestGit(VCSMixin, unittest.TestCase):
                 'subdir/sub2/sub3/file4',
             ])
 
+    def test_get_versioned_files_with_git_submodules_with_git_index_file_set(self):
+        with mock.patch.dict(os.environ, {"GIT_INDEX_FILE": ".git/index"}):
+            self.test_get_versioned_files_with_git_submodules()
+
 
 class BzrHelper(VCSHelper):
 


### PR DESCRIPTION
Instead of running `git ls-files` in each git submodule, run

        $ git ls-file --recurse-submodules

from the git root directory and list all files  under version control in one go.

This fixes a bug when check-manifest would fail with

        ['git', 'ls-files', '-z'] failed (status 128):
        fatal: .git/index: index file open failed: Not a directory

when run from a pre-commit hook. When running from a pre-commit hook, git sets `GIT_INDEX_FILE=.git/index`, which should be interpreted relative to the git root directory. When changing directories into a submodule directory  (say `./submodule/`)  and running `git ls-files` there, git expects to find a git index file at `./submodule/.git/index`, which fails since `./submodule/.git` is a regular file in a submodule.

The easy solution is to just pass `--recurse-submodules` when listing files under  version control and remove all logic  listing submodules files one-by-one.

A test is added that sets `GIT_INDEX_FILE=.git/index` and checks that tests dealing with submodules still pass. This simulates the "running from git-hook" setting

Fixes #122.