### PR TITLE
Only recurse into submodules if `.submodules` exists

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -394,10 +394,14 @@ class Git(VCS):
         # .git can be a file for submodules
         return os.path.exists(os.path.join(location, cls.metadata_name))
 
+    def _has_submodules(cls):
+        return os.path.exists(".gitmodules")
+
     def get_versioned_files(self):
         """List all files versioned by git in the current directory."""
+        extra_args = ["--recurse-submodules"] if self._has_submodules() else []
         output = run(
-            ["git", "ls-files", "-z", "--recurse-submodules"],
+            ["git", "ls-files", "-z"] + extra_args,
             encoding=self._encoding,
         )
         # -z tells git to use \0 as a line terminator; split() treats it as a


### PR DESCRIPTION
`git` before version 2.11 does not know the `--recurse-submodules` flag. Some OSes (RHEL 7, Debian Jessie, Ubuntu 16.04 LTS) still ship with versions older than that.

With this change, `git` is only passed `--recurse-submodules` if the repo in question has submodules configured, as indicated by the presence of `.gitmodules`. This prevents bugs like #123 on newer platforms, while still supporting older platforms, as long as repos there do not have submodules configured.

This fixes #124.

---

Does this look like it would be enough to make `check-manifest` work on older platforms? I cant really test it right now.