### PR TITLE
Require test coverage to be 100%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - pip install -e .[test]
 script:
     - SKIP_NO_TESTS=1 coverage run -m pytest
-    - coverage report -m
+    - coverage report -m --fail-under=100
     - python check_manifest.py
     - flake8 *.py
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - pip install -e .[test]
 script:
     - SKIP_NO_TESTS=1 coverage run -m pytest
-    - coverage report -m --fail-under=100
+    - coverage report -m --fail-under=$(if [[ $FORCE_TEST_VCS == bzr ]]; then printf 99; else printf 100; fi)
     - python check_manifest.py
     - flake8 *.py
 after_script:


### PR DESCRIPTION
I used to rely on coveralls.io for this, but coveralls is unreliable: I
never see their commit statuses on my repositories.  (Maybe they also
have GitHub API rate limiting problems like travis-ci.org?)