### PR TITLE
Add --no-build-isolation so check-manifest can succeed without an internet connection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@ Changelog
 
 - Drop Python 3.5 support.
 
+- Switch from ``pep517`` to `python-build <https://pypi.org/p/build>`__ (
+  `#128 <https://github.com/mgedmin/check-manifest/pull/128>`__).
+
+- Add ``--no-build-isolation`` option so check-manifest can succeed building
+  pep517-based distributions without an internet connection.  With
+  ``--no-build-isolation``, you must preinstall the ``build-system.requires``
+  beforehand. (
+  `#128 <https://github.com/mgedmin/check-manifest/pull/128>`__).
+
 
 0.44 (2020-10-03)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,21 @@ git-workflow. Add the following to your ``.pre-commit-config.yaml``.
         hooks:
         -   id: check-manifest
 
+If you are running pre-commit without a network, you can utilize
+``args: [--no-build-isolation]`` to prevent a ``pip install`` reaching out to
+pypi.  If you have additional ``build-system.requires`` outside of pip /
+setuptools / wheel you will want to list those in ``additional_dependencies``.
+
+.. code-block:: yaml
+
+    repos:
+    -   repo: https://github.com/mgedmin/check-manifest
+        rev: ...  # pick a valid tag / revision
+        hooks:
+        -   id: check-manifest
+            args: [--no-build-isolation]
+            additional_dependencies: [setuptools-scm]
+
 
 .. |buildstatus| image:: https://api.travis-ci.com/mgedmin/check-manifest.svg?branch=master
 .. _buildstatus: https://travis-ci.com/mgedmin/check-manifest

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[
-        'pep517',
+        'build>=0.1',
         'setuptools',
         'toml',
     ],

--- a/tests.py
+++ b/tests.py
@@ -606,7 +606,7 @@ class Tests(unittest.TestCase):
         with cd(src_dir):
             self.assertTrue(should_use_pep_517())
 
-    def test_build_sdist(self):
+    def _test_build_sdist_pep517(self, build_isolation):
         from check_manifest import build_sdist, cd, get_one_file_in
         src_dir = self.make_temp_dir()
         filename = os.path.join(src_dir, 'pyproject.toml')
@@ -621,8 +621,14 @@ class Tests(unittest.TestCase):
         out_dir = self.make_temp_dir()
         python = os.path.abspath(sys.executable)
         with cd(src_dir):
-            build_sdist(out_dir, python=python)
+            build_sdist(out_dir, python=python, build_isolation=build_isolation)
         self.assertTrue(get_one_file_in(out_dir))
+
+    def test_build_sdist_pep517_isolated(self):
+        self._test_build_sdist_pep517(build_isolation=True)
+
+    def test_build_sdist_pep517_no_isolation(self):
+        self._test_build_sdist_pep517(build_isolation=False)
 
 
 class TestConfiguration(unittest.TestCase):


### PR DESCRIPTION
this is a bit of a proof-of-concept I wanted to float before committing more to this

the reason I wanted to try and tackle this is @graingert wanted to use check-manifest in https://pre-commit.ci (which forbids network at runtime for free tier because I'd rather not deal with abuse for free 😄)

with this dockerfile:

```dockerfile
FROM ubuntu:focal
RUN : \
    && apt-get update \
    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        git \
        ca-certificates \
        python3-venv \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*
RUN git clone https://github.com/twisted/ldaptor
COPY . /code
RUN python3 -m venv /venv && /venv/bin/pip install /code wheel
```

I'm able to get ldaptor passing:

```console
$ docker run --rm -ti --net=none --workdir /ldaptor foo /venv/bin/check-manifest --no-build-isolation
lists of files in version control and sdist match
```