### PR TITLE
Remove "universal" from bdist_wheel configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 norecursedirs = dist build tmp .* *.egg-info
 python_files = tests.py check_manifest.py


### PR DESCRIPTION
Since commit f56a51f2b229c0a5bf1f9f70a66b801934b544b8, the project is
Python 2 only. As such, the wheel is not universal. Per docs:
https://wheel.readthedocs.io/en/stable/user_guide.html

> If your project ... is expected to work on both Python 2 and 3, you
> will want to tell wheel to produce universal wheels by adding this to
> your setup.cfg file: