### PR TITLE
Use pyupgrade to update project's code for Python-3-only

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -156,7 +156,7 @@ def run(
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, cwd=cwd)
     except OSError as e:
-        raise Failure("could not run %s: %s" % (command, e))
+        raise Failure(f"could not run {command}: {e}")
     output, stderr = pipe.communicate()
     status = pipe.wait()
     if status != 0:

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import codecs
 import doctest
 import locale
@@ -36,7 +34,7 @@ else:
     HAS_OEM_CODEC = True
 
 
-class MockUI(object):
+class MockUI:
 
     def __init__(self, verbosity=1):
         self.verbosity = verbosity
@@ -163,7 +161,7 @@ class Tests(unittest.TestCase):
                 with mock.patch('os.mkdir',
                                 lambda d: actions.append('mkdir %s' % d)):
                     with mock.patch('shutil.copy2',
-                                    lambda s, d: actions.append('cp %s %s' % (s, d))):
+                                    lambda s, d: actions.append(f'cp {s} {d}')):
                         copy_files(['a', 'b', n('c/d/e')], n('/dest/dir'))
         self.assertEqual(
             actions,
@@ -253,7 +251,7 @@ class Tests(unittest.TestCase):
             format_missing(set(), set(), "1st", "2nd"),
             "")
         self.assertEqual(
-            format_missing(set(["c"]), set(["a"]), "1st", "2nd"),
+            format_missing({"c"}, {"a"}, "1st", "2nd"),
             "missing from 1st:\n"
             "  c\n"
             "missing from 2nd:\n"
@@ -918,7 +916,7 @@ class TestZestIntegration(unittest.TestCase):
         sys_exit.assert_not_called()
 
 
-class VCSHelper(object):
+class VCSHelper:
 
     # override in subclasses
     command = None  # type: Optional[str]
@@ -952,7 +950,7 @@ class VCSHelper(object):
             raise subprocess.CalledProcessError(rc, command[0], output=stdout)
 
 
-class VCSMixin(object):
+class VCSMixin:
 
     def setUp(self):
         if not self.vcs.is_installed() and CAN_SKIP_TESTS:


### PR DESCRIPTION
pyupgrade is a command line tool up to update source code to use modern
Python syntax and patterns.

- Drop inheritance from "object". In Python 3, all classes a new-style
classes.

- Use f-strings when the expression is simple and readable.

- Drop unnecessary `__future__` imports.

- Use set literals.