### PR TITLE
Add 'language_version: python3' to .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,6 @@
     description: Check the completeness of MANIFEST.in for Python packages.
     entry: check-manifest
     language: python
+    language_version: python3
     pass_filenames: false
     always_run: true


### PR DESCRIPTION
By default, pre-commit uses they system Python. On some systems, this
could be Python 2. To ensure the hook always runs with Python 3, be
explicit.