### PR TITLE
Doc the pre-commit hook always uses Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 0.46 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- The `pre-commit <https://pre-commit.com>`__ hook now always uses Python 3.
 
 
 0.45 (2020-10-31)


### PR DESCRIPTION
Follows commit 0f30abfc3b65696f0ca54d1b5387f71bc91b070a.