### PR TITLE
Fix for extracting version incorrectly from sdist filename containing dashes

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -879,7 +879,7 @@ def extract_version_from_filename(filename):
     filename = os.path.splitext(os.path.basename(filename))[0]
     if filename.endswith('.tar'):
         filename = os.path.splitext(filename)[0]
-    return filename.partition('-')[2]
+    return filename.split('-')[-1]
 
 
 def should_use_pep_517():

--- a/tests.py
+++ b/tests.py
@@ -464,6 +464,7 @@ class Tests(unittest.TestCase):
         from check_manifest import extract_version_from_filename as e
         self.assertEqual(e('dist/foo_bar-1.2.3.dev4+g12345.zip'), '1.2.3.dev4+g12345')
         self.assertEqual(e('dist/foo_bar-1.2.3.dev4+g12345.tar.gz'), '1.2.3.dev4+g12345')
+        self.assertEqual(e('dist/foo-bar-1.2.3.dev4+g12345.tar.gz'), '1.2.3.dev4+g12345')
 
     def test_get_ignore_from_manifest_lines(self):
         from check_manifest import IgnoreList, _get_ignore_from_manifest_lines


### PR DESCRIPTION
This commit attempts to fix (#145) filename parsing to extract the version string correctly.

Checklist
- Added test case
- Tested wheel packaging