### PR TITLE
Switch to tomli instead of toml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 
 - Add Python 3.10 support.
 
+- Switch to tomli instead of toml, after hearing about PEP-680.  tomli will be
+  included in the Python 3.11 standard library as tomllib, while toml is
+  apparently unmaintained.
+
 
 0.47 (2021-09-22)
 -----------------

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -34,7 +34,7 @@ from contextlib import contextmanager
 from typing import List, Optional, Union
 from xml.etree import ElementTree as ET
 
-import toml
+import tomli
 from setuptools.command.egg_info import translate_pattern
 
 
@@ -699,7 +699,8 @@ def _load_config():
 
     """
     if os.path.exists("pyproject.toml"):
-        config = toml.load("pyproject.toml")
+        with open('pyproject.toml', 'rb') as f:
+            config = tomli.load(f)
         if CFG_SECTION_CHECK_MANIFEST in config.get("tool", {}):
             return config["tool"][CFG_SECTION_CHECK_MANIFEST]
 
@@ -890,7 +891,8 @@ def should_use_pep_517():
     # should revert to the legacy behaviour of running setup.py".
     if not os.path.exists('pyproject.toml'):
         return False
-    config = toml.load("pyproject.toml")
+    with open('pyproject.toml', 'rb') as f:
+        config = tomli.load(f)
     if "build-system" not in config:
         return False
     if "build-backend" not in config["build-system"]:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         'build>=0.1',
         'setuptools',
-        'toml',
+        'tomli',
     ],
     extras_require={
         'test': [

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ basepython = python3
 skip_install = true
 deps =
     mypy
-    types-toml
 commands = mypy {posargs:check_manifest.py}
 
 [testenv:isort]


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0680/: [tomli](https://pypi.org/project/tomli/) will be included in the Python 3.11 standard library (as `tomllib`), while [toml](https://pypi.org/project/toml/) is apparently unmaintained.
