### PR TITLE
Use stdlib mock instead of backport package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     ],
     extras_require={
         'test': [
-            'mock >= 3.0.0',
             'pytest',
         ],
     },

--- a/tests.py
+++ b/tests.py
@@ -16,7 +16,7 @@ from io import BytesIO, StringIO
 from typing import Optional
 from xml.etree import ElementTree as ET
 
-import mock
+from unittest import mock
 
 from check_manifest import rmtree
 


### PR DESCRIPTION
`unittest.mock` has been part of the stdlib since Python 3.3 so we can drop the backport package.

https://docs.python.org/3/library/unittest.mock.html