### PR TITLE
Use stdlib mock instead of backport package for Python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'mock >= 3.0.0',
+            'mock >= 3.0.0; python_version == "3.7"',
             'pytest',
         ],
     },

--- a/tests.py
+++ b/tests.py
@@ -16,7 +16,12 @@ from io import BytesIO, StringIO
 from typing import Optional
 from xml.etree import ElementTree as ET
 
-import mock
+if sys.version_info >= (3, 8):
+    from unittest import mock
+else:
+    # unittest.mock in 3.7 is too old to support
+    # all the features used in the test suite
+    import mock
 
 from check_manifest import rmtree
 

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,7 @@ from io import BytesIO, StringIO
 from typing import Optional
 from xml.etree import ElementTree as ET
 
+
 if sys.version_info >= (3, 8):
     from unittest import mock
 else:


### PR DESCRIPTION
Fixes #151.

We still need to use the backport for Python 3.7 because the version it has is too old for the features used in the test suite, but we don't need to install it for modern Python versions.

The conditional install can be removed when 3.7 is EOL in June 2023.