### PR TITLE
Fix git submodule tests using file: protocol

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1069,7 +1069,7 @@ class GitHelper(VCSHelper):
             self._run('git', 'init')
         self._run('git', 'config', 'user.name', 'Unit Test')
         self._run('git', 'config', 'user.email', 'test@example.com')
-        self._run('git', 'config', 'protocol.http.allow', 'always')
+        self._run('git', 'config', 'protocol.file.allow', 'always')
 
     def _add_to_vcs(self, filenames):
         # Note that we use --force to prevent errors when we want to

--- a/tests.py
+++ b/tests.py
@@ -1069,6 +1069,7 @@ class GitHelper(VCSHelper):
             self._run('git', 'init')
         self._run('git', 'config', 'user.name', 'Unit Test')
         self._run('git', 'config', 'user.email', 'test@example.com')
+        self._run('git', 'config', 'protocol.http.allow', 'always')
 
     def _add_to_vcs(self, filenames):
         # Note that we use --force to prevent errors when we want to

--- a/tests.py
+++ b/tests.py
@@ -1069,7 +1069,6 @@ class GitHelper(VCSHelper):
             self._run('git', 'init')
         self._run('git', 'config', 'user.name', 'Unit Test')
         self._run('git', 'config', 'user.email', 'test@example.com')
-        self._run('git', 'config', 'protocol.file.allow', 'always')
 
     def _add_to_vcs(self, filenames):
         # Note that we use --force to prevent errors when we want to
@@ -1094,7 +1093,8 @@ class TestGit(VCSMixin, unittest.TestCase):
 
     def _add_submodule(self, repo, subdir, subrepo):
         os.chdir(repo)
-        self.vcs._run('git', 'submodule', 'add', subrepo, subdir)
+        self.vcs._run('git', '-c', 'protocol.file.allow=always',
+                      'submodule', 'add', subrepo, subdir)
         self._commit()
         os.chdir(self.tmpdir)
 

--- a/tests.py
+++ b/tests.py
@@ -1053,7 +1053,7 @@ class GitHelper(VCSHelper):
     command = 'git'
 
     def _init_vcs(self):
-        self._run('git', 'init')
+        self._run('git', 'init', '-b', 'main')
         self._run('git', 'config', 'user.name', 'Unit Test')
         self._run('git', 'config', 'user.email', 'test@example.com')
 


### PR DESCRIPTION
Git 2.30.6 (and 2.31.5, and 2.32.4, and 2.33.5, and 2.34.5, and 2.35.5, and 2.36.3, and 2.37.4, and 2.38.1, and I suppose the forthcoming 2.39.0) forbids file:// protocols by default for git submodules, as a security measure.

See https://github.com/git/git/commit/a1d4f67c12ac172f835e6d5e4e0a197075e2146b for details.

No Ubuntu version ships a Git with that patch, so it's hard for me to test the fix locally.