### PR TITLE
fix: failing tests due to changed git behaviour after security fix

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1098,7 +1098,8 @@ class TestGit(VCSMixin, unittest.TestCase):
 
     def _add_submodule(self, repo, subdir, subrepo):
         os.chdir(repo)
-        self.vcs._run('git', 'submodule', 'add', subrepo, subdir)
+        self.vcs._run('git', '-c', 'protocol.file.allow=always', 'submodule',
+                      'add', subrepo, subdir)
         self._commit()
         os.chdir(self.tmpdir)
 
@@ -1123,7 +1124,8 @@ class TestGit(VCSMixin, unittest.TestCase):
         self._add_submodule('main', 'sub1', '../repo1')
         self._add_submodule('main', 'subdir/sub2', '../repo2')
         os.chdir('main')
-        self.vcs._run('git', 'submodule', 'update', '--init', '--recursive')
+        self.vcs._run('git', '-c', 'protocol.file.allow=always', 'submodule',
+                      'update', '--init', '--recursive')
         self.assertEqual(
             get_vcs_files(self.ui),
             [


### PR DESCRIPTION
Reference: https://github.com/git/git/security/advisories/GHSA-3wp6-j8xr-qw85

Test failure log (sorry for German locale):

```
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.8, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/chris/work/aur/check-manifest/src/check-manifest-0.47, configfile: setup.cfg
plugins: anyio-3.6.2, cov-4.0.0
collected 148 items                                                                                                                                                                                                                                          

tests.py .............................................................................FFssssss....s..........................................................                                                                                          [100%]

========================================================================================================================== FAILURES ==========================================================================================================================
____________________________________________________________________________________________________ TestGit.test_get_versioned_files_with_git_submodules ____________________________________________________________________________________________________

self = <tests.TestGit testMethod=test_get_versioned_files_with_git_submodules>

    def test_get_versioned_files_with_git_submodules(self):
        from check_manifest import get_vcs_files
        self._init_repo_with_files('repo1', ['file1', 'file2'])
        self._init_repo_with_files('repo2', ['file3'])
        self._init_repo_with_files('repo3', ['file4'])
>       self._add_submodule('repo2', 'sub3', '../repo3')

tests.py:1095: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests.py:1075: in _add_submodule
    self.vcs._run('git', 'submodule', 'add', subrepo, subdir)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.GitHelper object at 0x7fa031573640>, command = ('git', 'submodule', 'add', '../repo3', 'sub3'), p = <Popen: returncode: 128 args: ('git', 'submodule', 'add', '../repo3', 'sub3')>
stdout = b"Klone nach '/home/chris/tmp/test-tqdboj_w-check-manifest/repo2/sub3'...\nSchwerwiegend: \xc3\x9cbertragungsart 'file...j_w-check-manifest/repo3' in Submodul-Pfad '/home/chris/tmp/test-tqdboj_w-check-manifest/repo2/sub3' fehlgeschlagen.\n"
stderr = None

    def _run(self, *command):
        # Windows doesn't like Unicode arguments to subprocess.Popen(), on Py2:
        # https://github.com/mgedmin/check-manifest/issues/23#issuecomment-33933031
        if str is bytes:
            command = [s.encode(locale.getpreferredencoding()) for s in command]
        print('$', ' '.join(command))
        p = subprocess.Popen(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
        stdout, stderr = p.communicate()
        rc = p.wait()
        if stdout:
            print(
                stdout if isinstance(stdout, str) else
                stdout.decode('ascii', 'backslashreplace')
            )
        if rc:
>           raise subprocess.CalledProcessError(rc, command[0], output=stdout)
E           subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.

tests.py:950: CalledProcessError
-------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------
$ git init
Leeres Git-Repository in /home/chris/tmp/test-tqdboj_w-check-manifest/repo1/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file1 file2
$ git commit -m Initial
[master (Root-Commit) 4031a2c] Initial
 2 files changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file1
 create mode 100644 file2

$ git init
Leeres Git-Repository in /home/chris/tmp/test-tqdboj_w-check-manifest/repo2/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file3
$ git commit -m Initial
[master (Root-Commit) fd3797a] Initial
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file3

$ git init
Leeres Git-Repository in /home/chris/tmp/test-tqdboj_w-check-manifest/repo3/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file4
$ git commit -m Initial
[master (Root-Commit) 7bd536a] Initial
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file4

$ git submodule add ../repo3 sub3
Klone nach '/home/chris/tmp/test-tqdboj_w-check-manifest/repo2/sub3'...
Schwerwiegend: \xc3\x9cbertragungsart 'file' nicht erlaubt.
Schwerwiegend: Klonen von '/home/chris/tmp/test-tqdboj_w-check-manifest/repo3' in Submodul-Pfad '/home/chris/tmp/test-tqdboj_w-check-manifest/repo2/sub3' fehlgeschlagen.

________________________________________________________________________________________ TestGit.test_get_versioned_files_with_git_submodules_with_git_index_file_set ________________________________________________________________________________________

self = <tests.TestGit testMethod=test_get_versioned_files_with_git_submodules_with_git_index_file_set>

    def test_get_versioned_files_with_git_submodules_with_git_index_file_set(self):
        with mock.patch.dict(os.environ, {"GIT_INDEX_FILE": ".git/index"}):
>           self.test_get_versioned_files_with_git_submodules()

tests.py:1116: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests.py:1095: in test_get_versioned_files_with_git_submodules
    self._add_submodule('repo2', 'sub3', '../repo3')
tests.py:1075: in _add_submodule
    self.vcs._run('git', 'submodule', 'add', subrepo, subdir)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tests.GitHelper object at 0x7fa031573640>, command = ('git', 'submodule', 'add', '../repo3', 'sub3'), p = <Popen: returncode: 128 args: ('git', 'submodule', 'add', '../repo3', 'sub3')>
stdout = b"Klone nach '/home/chris/tmp/test-gjqaobcv-check-manifest/repo2/sub3'...\nSchwerwiegend: \xc3\x9cbertragungsart 'file...bcv-check-manifest/repo3' in Submodul-Pfad '/home/chris/tmp/test-gjqaobcv-check-manifest/repo2/sub3' fehlgeschlagen.\n"
stderr = None

    def _run(self, *command):
        # Windows doesn't like Unicode arguments to subprocess.Popen(), on Py2:
        # https://github.com/mgedmin/check-manifest/issues/23#issuecomment-33933031
        if str is bytes:
            command = [s.encode(locale.getpreferredencoding()) for s in command]
        print('$', ' '.join(command))
        p = subprocess.Popen(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
        stdout, stderr = p.communicate()
        rc = p.wait()
        if stdout:
            print(
                stdout if isinstance(stdout, str) else
                stdout.decode('ascii', 'backslashreplace')
            )
        if rc:
>           raise subprocess.CalledProcessError(rc, command[0], output=stdout)
E           subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.

tests.py:950: CalledProcessError
-------------------------------------------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------------------------------------------
$ git init
Leeres Git-Repository in /home/chris/tmp/test-gjqaobcv-check-manifest/repo1/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file1 file2
$ git commit -m Initial
[master (Root-Commit) 4031a2c] Initial
 2 files changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file1
 create mode 100644 file2

$ git init
Leeres Git-Repository in /home/chris/tmp/test-gjqaobcv-check-manifest/repo2/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file3
$ git commit -m Initial
[master (Root-Commit) fd3797a] Initial
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file3

$ git init
Leeres Git-Repository in /home/chris/tmp/test-gjqaobcv-check-manifest/repo3/.git/ initialisiert

$ git config user.name Unit Test
$ git config user.email test@example.com
$ git add --force -- file4
$ git commit -m Initial
[master (Root-Commit) 7bd536a] Initial
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 file4

$ git submodule add ../repo3 sub3
Klone nach '/home/chris/tmp/test-gjqaobcv-check-manifest/repo2/sub3'...
Schwerwiegend: \xc3\x9cbertragungsart 'file' nicht erlaubt.
Schwerwiegend: Klonen von '/home/chris/tmp/test-gjqaobcv-check-manifest/repo3' in Submodul-Pfad '/home/chris/tmp/test-gjqaobcv-check-manifest/repo2/sub3' fehlgeschlagen.

================================================================================================================== short test summary info ===================================================================================================================
FAILED tests.py::TestGit::test_get_versioned_files_with_git_submodules - subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.
FAILED tests.py::TestGit::test_get_versioned_files_with_git_submodules_with_git_index_file_set - subprocess.CalledProcessError: Command 'git' returned non-zero exit status 128.
========================================================================================================= 2 failed, 139 passed, 7 skipped in 25.23s ==========================================================================================================
```