### PR TITLE
drop python<=3.7 support

### DIFF
--- a/check_manifest.py
+++ b/check_manifest.py
@@ -137,7 +137,7 @@ def format_missing(missing_from_a, missing_from_b, name_a, name_b):
 
 class CommandFailed(Failure):
     def __init__(self, command: List[str], status: int, output: str) -> None:
-        super().__init__("%s failed (status %s):\n%s" % (
+        super().__init__("{} failed (status {}):\n{}".format(
                                command, status, output))
 
 

--- a/tests.py
+++ b/tests.py
@@ -18,21 +18,7 @@ from typing import Dict, Optional
 from xml.etree import ElementTree as ET
 
 
-if sys.version_info >= (3, 8):
-    from unittest import mock
-else:
-    # unittest.mock in 3.7 is too old to support
-    # all the features used in the test suite
-    import mock
-
-from check_manifest import rmtree
-
-
-CAN_SKIP_TESTS = os.getenv('SKIP_NO_TESTS', '') == ''
-
-
-try:
-    codecs.lookup('oem')
+from unittest import mock
 except LookupError:
     HAS_OEM_CODEC = False
 else:
@@ -115,7 +101,7 @@ class Tests(unittest.TestCase):
         should_start_with = "could not run ['there-is-really-no-such-program']:"
         self.assertTrue(
             str(cm.exception).startswith(should_start_with),
-            '\n%r does not start with\n%r' % (str(cm.exception),
+            '\n{!r} does not start with\n{!r}'.format(str(cm.exception),
                                               should_start_with))
 
     def test_mkdtemp_readonly_files(self):
@@ -179,7 +165,7 @@ class Tests(unittest.TestCase):
                 'cp a %s' % n('/dest/dir/a'),
                 'mkdir %s' % n('/dest/dir/b'),
                 'makedirs %s' % n('/dest/dir/c/d'),
-                'cp %s %s' % (n('c/d/e'), n('/dest/dir/c/d/e')),
+                'cp {} {}'.format(n('c/d/e'), n('/dest/dir/c/d/e')),
             ])
 
     def test_get_one_file_in(self):


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.