### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Check test coverage
         run: |
           coverage xml
-          coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 98 || 100 }}
+          coverage report -m --fail-under=${{ runner.os == 'Windows' && '98' || matrix.vcs == 'bzr' && 99 || 100 }}
 
       - name: Run check-manifest on itself
         run: python check_manifest.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Check test coverage
         run: |
           coverage xml
-          coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 99 || 100 }}
+          coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 98 || 100 }}
 
       - name: Run check-manifest on itself
         run: python check_manifest.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Check test coverage
         run: |
-          coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 99 || 100 }}
           coverage xml
+          coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 99 || 100 }}
 
       - name: Run check-manifest on itself
         run: python check_manifest.py

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -17,7 +17,6 @@ MANIFEST.in to be included nevertheless.
 from __future__ import annotations
 
 import argparse
-import codecs
 import configparser
 import fnmatch
 import locale
@@ -474,25 +473,7 @@ class Bazaar(VCS):
         # Python 3.6 lets us name the OEM codepage directly, which is lucky
         # because it also breaks our old method of OEM codepage detection
         # (PEP-528 changed sys.stdout.encoding to UTF-8).
-        try:
-            codecs.lookup('oem')
-        except LookupError:
-            pass
-        else:  # pragma: nocover
-            return 'oem'
-        # Based on bzrlib.osutils.get_terminal_encoding()
-        encoding = getattr(sys.stdout, 'encoding', None)
-        if not encoding:
-            encoding = getattr(sys.stdin, 'encoding', None)
-        if encoding == 'cp0':  # "no codepage"
-            encoding = None
-        # NB: bzrlib falls back on bzrlib.osutils.get_user_encoding(),
-        # which is like locale.getpreferredencoding() on steroids, and
-        # also includes a fallback from 'ascii' to 'utf-8' when
-        # sys.platform is 'darwin'.  This is probably something we might
-        # want to do in run(), but I'll wait for somebody to complain
-        # first, since I don't have a Mac OS X machine and cannot test.
-        return encoding
+        return 'oem'
 
     def get_versioned_files(self) -> list[str]:
         """List all files versioned in Bazaar in the current directory."""

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -17,6 +17,7 @@ MANIFEST.in to be included nevertheless.
 from __future__ import annotations
 
 import argparse
+import codecs
 import configparser
 import fnmatch
 import locale
@@ -473,7 +474,25 @@ class Bazaar(VCS):
         # Python 3.6 lets us name the OEM codepage directly, which is lucky
         # because it also breaks our old method of OEM codepage detection
         # (PEP-528 changed sys.stdout.encoding to UTF-8).
-        return 'oem'
+        try:
+            codecs.lookup('oem')
+        except LookupError:
+            pass
+        else:  # pragma: nocover
+            return 'oem'
+        # Based on bzrlib.osutils.get_terminal_encoding()
+        encoding = getattr(sys.stdout, 'encoding', None)
+        if not encoding:
+            encoding = getattr(sys.stdin, 'encoding', None)
+        if encoding == 'cp0':  # "no codepage"
+            encoding = None
+        # NB: bzrlib falls back on bzrlib.osutils.get_user_encoding(),
+        # which is like locale.getpreferredencoding() on steroids, and
+        # also includes a fallback from 'ascii' to 'utf-8' when
+        # sys.platform is 'darwin'.  This is probably something we might
+        # want to do in run(), but I'll wait for somebody to complain
+        # first, since I don't have a Mac OS X machine and cannot test.
+        return encoding
 
     def get_versioned_files(self) -> list[str]:
         """List all files versioned in Bazaar in the current directory."""


### PR DESCRIPTION
If coverage report --fail-under is not the last command in a script, its exit code is thrown away.

This is how I've been living with 98% coverage on Windows jobs without noticing.

~~Also drop the unused/untested pre-Python 3.6 bzr encoding detection code.~~