### PR TITLE
Soft-deprecate Bazaar support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}, ${{ matrix.vcs }}
     # bzr works on ubuntu-22.04
     # brz is broken on ubuntu-22.04 and ubuntu-24.04 aka ubuntu-latest
+    # brz works on ubuntu-26.04
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr'}}
 
@@ -97,7 +98,7 @@ jobs:
 
           coverage run -m pytest
         env:
-          SKIP_NO_TESTS: "1"
+          SKIP_NO_TESTS: ${{ runner.os != 'Windows' && '1' || '' }}
           FORCE_TEST_VCS: ${{ matrix.vcs }}
 
       - name: Check test coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}, ${{ matrix.vcs }}
+    # bzr works on ubuntu-22.04
+    # brz is broken on ubuntu-22.04 and ubuntu-24.04 aka ubuntu-latest
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr'}}
 
@@ -29,7 +31,7 @@ jobs:
           - "3.14"
           - "pypy3.11"
         os:
-          - ubuntu-latest
+          - ubuntu-26.04
           - windows-latest
         vcs:
           - bzr

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}, ${{ matrix.vcs }}
-    # bzr works on ubuntu-22.04
-    # brz is broken on ubuntu-22.04 and ubuntu-24.04 aka ubuntu-latest
-    # brz works on ubuntu-26.04
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr' || matrix.os == 'windows-latest' }}
 
@@ -32,7 +29,9 @@ jobs:
           - "3.14"
           - "pypy3.11"
         os:
-          - ubuntu-26.04
+          # bzr works on ubuntu-22.04
+          # brz is broken on ubuntu-22.04 and ubuntu-24.04 aka ubuntu-latest and also on ubuntu-26.04
+          - ubuntu-22.04
           - windows-latest
         vcs:
           - bzr
@@ -44,7 +43,7 @@ jobs:
       - name: Install OS-level dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y brz git mercurial subversion
+          sudo apt-get install -y bzr git mercurial subversion
 
       - name: Install OS-level dependencies (Windows)
         if: runner.os == 'Windows'
@@ -57,7 +56,7 @@ jobs:
         # if you try to download the bzr windows installer, so only try to
         # install it for matrix.vcs == 'bzr' jobs
         run: |
-          choco install --no-progress bzr hg svn
+          choco install --no-progress bzr
 
       - name: Git clone
         uses: actions/checkout@v6
@@ -98,7 +97,7 @@ jobs:
 
           coverage run -m pytest
         env:
-          SKIP_NO_TESTS: ${{ runner.os != 'Windows' && '1' || '' }}
+          SKIP_NO_TESTS: ${{ matrix.vcs == 'bzr' && '1' || '' }}
           FORCE_TEST_VCS: ${{ matrix.vcs }}
 
       - name: Check test coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           git --version
           hg --version
           svn --version
-          bzr --version
+          bzr --version || true
 
           coverage run -m pytest
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     # brz is broken on ubuntu-22.04 and ubuntu-24.04 aka ubuntu-latest
     # brz works on ubuntu-26.04
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr'}}
+    continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr' || matrix.os == 'windows-latest' }}
 
     strategy:
       fail-fast: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}, ${{ matrix.vcs }}
-    # ubuntu-latest aka ubuntu-24.04 has busted bzr
-    runs-on: ${{ matrix.vcs == 'bzr' && matrix.os == 'ubuntu-latest' && 'ubuntu-22.04' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr'}}
 
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,9 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}, ${{ matrix.vcs }}
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.python-version == 'pypy3.11' }}
+    # ubuntu-latest aka ubuntu-24.04 has busted bzr
+    runs-on: ${{ matrix.vcs == 'bzr' && matrix.os == 'ubuntu-latest' && 'ubuntu-22.04' || matrix.os }}
+    continue-on-error: ${{ matrix.python-version == 'pypy3.11' || matrix.vcs == 'bzr'}}
 
     strategy:
       fail-fast: true
@@ -29,7 +30,7 @@ jobs:
           - "3.14"
           - "pypy3.11"
         os:
-          - ubuntu-22.04  # ubuntu-latest aka ubuntu-24.04 has busted bzr
+          - ubuntu-latest
           - windows-latest
         vcs:
           - bzr
@@ -39,15 +40,20 @@ jobs:
 
     steps:
       - name: Install OS-level dependencies (Linux)
-        # NB: at some point I'll want to switch from legacy Bazaar (apt package
-        # bzr) to Breezy (apt package brz).  They're both available in
-        # ubuntu-18.04 and ubuntu-20.04.
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y bzr git mercurial subversion
+          sudo apt-get install -y brz git mercurial subversion
 
       - name: Install OS-level dependencies (Windows)
         if: runner.os == 'Windows'
+        run: |
+          choco install --no-progress hg svn
+
+      - name: Install OS-level dependencies (Windows, bzr)
+        if: runner.os == 'Windows' && matrix.vcs == 'bzr'
+        # choco install bzr has been failing lately because launchpad times out
+        # if you try to download the bzr windows installer, so only try to
+        # install it for matrix.vcs == 'bzr' jobs
         run: |
           choco install --no-progress bzr hg svn
 
@@ -67,7 +73,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U setuptools wheel
           python -m pip install -U coverage pytest flake8
-          python -m pip install -e .[test]
+          python -m pip install -e '.[test]'
 
       - name: Run tests
         shell: bash

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 -----------------
 
 - Drop Python 3.8 and 3.9 support.
+- Soft-deprecate Bazaar support: it's becoming harder to install it on CI
+  systems, so I no longer guarantee that the code works.
 
 
 0.51 (2025-10-15)


### PR DESCRIPTION
Make Bazaar build failures ignorable on GitHub Actions.

Try installing brz instead of bzr on Ubuntu.

Skip installing bzr on Windows for matrix jobs that primarily test another VCS.

Try running tests on ubuntu-latest instead of sticking to an outdated ubuntu-22.04.

I expect this to fail on Windows because of SKIP_NO_TESTS in the job environment, due to the way my tests are structured.