### PR TITLE
Build PEP 517 sdists by importing build in-process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 0.52 (unreleased)
 -----------------
 
+- Build PEP 517 sdists by importing ``build`` in-process instead of running
+  ``python -m build``.  This works when ``build`` is only on the generated
+  script's ``sys.path`` (e.g. Buildout) and is not installed in the target
+  interpreter.  (`#172 <https://github.com/mgedmin/check-manifest/issues/172>`_)
+
 - Drop Python 3.8 and 3.9 support.
 
 

--- a/check_manifest.py
+++ b/check_manifest.py
@@ -982,17 +982,42 @@ def build_sdist(tempdir: str, python: str = sys.executable, build_isolation: boo
     you want to build.
     """
     if should_use_pep_517():
-        # I could do this in-process with
-        #   import build.__main__
-        #   build.__main__.build('.', tempdir)
-        # but then it would print a bunch of things to stdout and I'd have to
-        # worry about exceptions
-        cmd = [python, '-m', 'build', '--sdist', '.', '--outdir', tempdir]
-        if not build_isolation:
-            cmd.append('--no-isolation')
-        run(cmd)
+        _build_sdist_pep517(tempdir, isolation=build_isolation)
     else:
         run([python, 'setup.py', 'sdist', '-d', tempdir])
+
+
+def _build_sdist_pep517(tempdir: str, isolation: bool = True) -> None:
+    """Build an sdist by importing ``build`` in-process.
+
+    ``python -m build`` requires ``build`` to be installed in the *target*
+    interpreter.  That fails when ``build`` is only on the generated script's
+    ``sys.path`` (e.g. Buildout).  See issue #172.
+    """
+    from contextlib import redirect_stderr, redirect_stdout
+    from io import StringIO
+
+    from build import ProjectBuilder
+
+    stdout = StringIO()
+    stderr = StringIO()
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            if isolation:
+                from build.env import DefaultIsolatedEnv
+                with DefaultIsolatedEnv() as env:
+                    builder = ProjectBuilder.from_isolated_env(env, '.')
+                    env.install(builder.build_system_requires)
+                    env.install(builder.get_requires_for_build('sdist'))
+                    builder.build('sdist', tempdir)
+            else:
+                ProjectBuilder('.').build('sdist', tempdir)
+    except Exception as e:
+        captured = ''.join(
+            part for part in (stdout.getvalue(), stderr.getvalue()) if part
+        )
+        detail = f'{captured.rstrip()}\n{e}' if captured else str(e)
+        raise Failure(f'Failed to build sdist:\n{detail}') from e
 
 
 def check_manifest(

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.10",
     install_requires=[
-        'build>=0.1',
+        'build>=1.0',
         'setuptools',
         'tomli;python_version < "3.11"',
     ],

--- a/tests.py
+++ b/tests.py
@@ -639,6 +639,28 @@ class Tests(unittest.TestCase):
     def test_build_sdist_pep517_no_isolation(self):
         self._test_build_sdist_pep517(build_isolation=False)
 
+    def test_build_sdist_pep517_does_not_need_build_on_target_python(self):
+        # Issue #172: python -m build fails when build is only on the
+        # generated script's sys.path (Buildout), not in the target interpreter.
+        from check_manifest import build_sdist, cd, get_one_file_in
+        src_dir = self.make_temp_dir()
+        filename = os.path.join(src_dir, 'pyproject.toml')
+        self.create_file(filename, textwrap.dedent("""
+            [build-system]
+            requires = [
+                "setuptools >= 40.6.0",
+                "wheel",
+            ]
+            build-backend = "setuptools.build_meta"
+        """))
+        stub = os.path.join(self.make_temp_dir(), 'no-build-python')
+        self.create_file(stub, "#!/bin/sh\n" + 'echo "No module named build" >&2\n' + "exit 1\n")
+        os.chmod(stub, 0o755)
+        out_dir = self.make_temp_dir()
+        with cd(src_dir):
+            build_sdist(out_dir, python=stub, build_isolation=True)
+        self.assertTrue(get_one_file_in(out_dir))
+
 
 class TestConfiguration(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,9 @@ commands = flake8 {posargs:check_manifest.py setup.py tests.py}
 [testenv:mypy]
 basepython = python3
 skip_install = true
-deps = mypy
+deps =
+    mypy
+    build
 commands = mypy {posargs:check_manifest.py}
 
 [testenv:isort]


### PR DESCRIPTION
Fixes #172.

`check-manifest` currently builds PEP 517 sdists with `python -m build`. That fails when `build` is only on the generated script's `sys.path` (Buildout-style eggs) and is not installed in the target interpreter:

```
['.../bin/python3.12', '-m', 'build', '--sdist', '.', '--outdir', '...'] failed (status 1):
.../bin/python3.12: No module named build
```

`build` is already a dependency of check-manifest, so this switches PEP 517 builds to the public `ProjectBuilder` / `DefaultIsolatedEnv` API. Isolated and non-isolated builds both still work. `setup.py sdist` is unchanged.

Stdout/stderr from the in-process API are captured and included in the `Failure` message if the build fails.

Requires `build>=1.0` for `DefaultIsolatedEnv` and `ProjectBuilder.from_isolated_env`.